### PR TITLE
Handle unmapped records

### DIFF
--- a/readpaf.py
+++ b/readpaf.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 __all__ = ["parse_paf"]
 
-__version__ = "0.0.7a1"
+__version__ = "0.0.7"
 
 try:
     import pandas as pd

--- a/tests/static_files/test_unmapped.paf
+++ b/tests/static_files/test_unmapped.paf
@@ -1,0 +1,10 @@
+ead59ff7-cc16-46ed-8edd-eea5e185b3c5	878	110	713	+	Salmonella_enterica_complete_genome	4759746	2385487	2386084	121	604	60	tp:A:P	cm:i:19	s1:i:120	s2:i:0	dv:f:0.1195	rl:i:0
+60c06c3c-26c7-4f76-90b7-5305abf80866	614	5	72	+	Saccharomyces_cerevisiae_XII	1078177	490168	490232	52	67	0	tp:A:P	cm:i:4	s1:i:52	s2:i:52	dv:f:0.0674	rl:i:0
+60c06c3c-26c7-4f76-90b7-5305abf80866	614	5	72	+	Saccharomyces_cerevisiae_XII	1078177	461337	461401	52	67	0	tp:A:S	cm:i:4	s1:i:52	dv:f:0.0674	rl:i:0
+60c06c3c-26c7-4f76-90b7-5305abf80866	614	5	72	+	Saccharomyces_cerevisiae_XII	1078177	452200	452264	52	67	0	tp:A:S	cm:i:4	s1:i:52	dv:f:0.0674	rl:i:0
+ebd0b683-f140-415d-abd1-9b1cc3d295ab	2837	694	1768	-	Staphylococcus_aureus_chromosome	2718780	620963	622103	72	1140	30	tp:A:P	cm:i:7	s1:i:59	s2:i:0	dv:f:0.2221	rl:i:0
+d7fdd8e1-5660-4e9b-95b8-b421628a078c	2657	123	1848	-	Bacillus_subtilis_complete_genome	4045677	3512962	3514772	533	1830	60	tp:A:P	cm:i:66	s1:i:510	s2:i:0	dv:f:0.1055	rl:i:0
+78a6d441-122f-402e-a41b-b01316fd22a3	1130	132	665	+	Bacillus_subtilis_complete_genome	4045677	3918399	3918953	45	554	0	tp:A:P	cm:i:3	s1:i:40	s2:i:0	dv:f:0.2324	rl:i:0
+e6dfeea4-bc20-4e9e-b10c-12b8b6ac7020	4737	281	4712	+	Escherichia_coli_chromosome	4765434	303451	307674	304	4459	60	tp:A:P	cm:i:25	s1:i:253	s2:i:0	dv:f:0.2329	rl:i:0
+5ec9597c-74f1-4886-a43f-fcc8dd220228	2683	127	2543	+	Bacillus_subtilis_complete_genome	4045677	1715750	1718382	162	2632	19	tp:A:P	cm:i:13	s1:i:121	s2:i:106	dv:f:0.2360	rl:i:30
+2a708733-5e95-49e3-8806-e181e9380cd9	3715	*	*	*	*	*	*	*	*	*	61	mt:f:0.000000	ci:i:1	sl:i:3715

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -10,6 +10,22 @@ except ImportError:
 STATIC_FILES = os.path.join(os.path.dirname(os.path.realpath(__file__)), "static_files")
 PAF_FILE = os.path.join(STATIC_FILES, "test.paf")
 MISSING_LINE = os.path.join(STATIC_FILES, "test_blank_line.paf")
+UNMAPPED_REC = os.path.join(STATIC_FILES, "test_unmapped.paf")
+
+DEFAULT_COLS = [
+    "query_name",
+    "query_length",
+    "query_start",
+    "query_end",
+    "strand",
+    "target_name",
+    "target_length",
+    "target_start",
+    "target_end",
+    "residue_matches",
+    "alignment_block_length",
+    "mapping_quality",
+]
 
 
 def test_read_to_dataframe():
@@ -25,24 +41,17 @@ def test_read_missing_line():
     assert df.shape == (9, 18), "Not the right shape"
 
 
+def test_read_unmapped():
+    with open(UNMAPPED_REC, "r") as fh:
+        df = parse_paf(fh, dataframe=True)
+    null = df[DEFAULT_COLS].isnull().any(axis=1).sum()
+    assert null == 1, "Expected only one row with NaNs"
+
+
 def test_fields():
-    cols = [
-        "query_name",
-        "query_length",
-        "query_start",
-        "query_end",
-        "strand",
-        "target_name",
-        "target_length",
-        "target_start",
-        "target_end",
-        "residue_matches",
-        "alignment_block_length",
-        "mapping_quality",
-    ]
     with open(PAF_FILE, "r") as fh:
         df = parse_paf(fh, dataframe=True)
-    assert set(cols).issubset(set(df.columns)), "Fields not set correctly"
+    assert set(DEFAULT_COLS).issubset(set(df.columns)), "Fields not set correctly"
 
 
 def test_tag_suffix():

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -22,6 +22,7 @@ else:
 STATIC_FILES = os.path.join(os.path.dirname(os.path.realpath(__file__)), "static_files")
 PAF_FILE = os.path.join(STATIC_FILES, "test.paf")
 MISSING_LINE = os.path.join(STATIC_FILES, "test_blank_line.paf")
+UNMAPPED_REC = os.path.join(STATIC_FILES, "test_unmapped.paf")
 
 
 def test_read_uncompressed():
@@ -73,3 +74,11 @@ def test_request_dataframe():
     with pytest.raises(ImportError):
         with open(PAF_FILE, "r") as fh:
             _ = parse_paf(fh, dataframe=True)
+
+
+def test_read_unmapped():
+    c = 0
+    with open(UNMAPPED_REC, "r") as fh:
+        for record in parse_paf(fh):
+            c += 1
+    assert c == 10, "Incorrect number of records"


### PR DESCRIPTION
Closes #1 

An unmapped record created using `--paf-no-hit` will have the strand and reference (fields 5 and 6) set to `*`. These are implicitly handled in v0.0.6 as all strand and references are treated as strings. Tools that output PAF-like files such as [sigmap](https://github.com/haowenz/sigmap) do not mimic minimap2 which outputs `0` in numeric fields instead using `*` 

<details>
<summary>minimap2 unmapped record</summary>
<pre>
276b4f7a-8aa6-43c6-9fe4-87029f2c6360    1028    0       0       *       *       0       0       0       0       0       0       rl:i:0
</pre>
</details>

<details>
<summary>sigmap unmapped record</summary>
<pre>
2a708733-5e95-49e3-8806-e181e9380cd9	3715	*	*	*	*	*	*	*	*	*	61	mt:f:0.000000	ci:i:1	sl:i:3715
</pre>
</details>