### PR TITLE
Handle cs tag

### DIFF
--- a/readpaf.py
+++ b/readpaf.py
@@ -95,7 +95,7 @@ def _parse_tags(tags):
     """
     return {
         tag: SAM_TAG(tag, type_, SAM_TYPES.get(type_, lambda x: x)(val))
-        for tag, type_, val in (x.split(":", maxsplit=2) for x in tags)
+        for tag, type_, val in (x.split(":", 2) for x in tags)
     }
 
 

--- a/readpaf.py
+++ b/readpaf.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 __all__ = ["parse_paf"]
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 try:
     import pandas as pd
@@ -95,7 +95,7 @@ def _parse_tags(tags):
     """
     return {
         tag: SAM_TAG(tag, type_, SAM_TYPES.get(type_, lambda x: x)(val))
-        for tag, type_, val in (x.split(":") for x in tags)
+        for tag, type_, val in (x.split(":", maxsplit=2) for x in tags)
     }
 
 

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -63,7 +63,7 @@ def test_fields_dataframe():
 
 
 def test_tag_suffix_dataframe():
-    _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\n"
+    _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\tcs:Z::6-ata:10+gtc:4*at:3\n"
     PAF_IO = StringIO(_rec)
     cols = [
         "query_name",
@@ -80,7 +80,7 @@ def test_tag_suffix_dataframe():
         "mapping_quality",
     ]
     df = parse_paf(PAF_IO, fields=cols + ["tags"], dataframe=True)
-    assert set(df.columns) == set(cols + ["tp_tag"]), "Tag field not set correctly"
+    assert set(df.columns) == set(cols + ["cs", "tp_tag"]), "Tag field not set correctly"
 
 
 def test_read_uncompressed():

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -82,11 +82,13 @@ def test_tag_suffix_dataframe():
     df = parse_paf(PAF_IO, fields=cols + ["tags"], dataframe=True)
     assert set(df.columns) == set(cols + ["tp_tag"]), "Tag field not set correctly"
 
+
 def test_cs_tag_parsing():
     _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\tcs:Z::6-ata:10+gtc:4*at:3\n"
     PAF_IO = StringIO(_rec)
     for rec in parse_paf(PAF_IO):
         assert rec.tags["cs"].value == ":6-ata:10+gtc:4*at:3", "cs tag didn't match"
+
 
 def test_read_uncompressed():
     c = 0

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -63,7 +63,7 @@ def test_fields_dataframe():
 
 
 def test_tag_suffix_dataframe():
-    _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\tcs:Z::6-ata:10+gtc:4*at:3\n"
+    _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\n"
     PAF_IO = StringIO(_rec)
     cols = [
         "query_name",
@@ -80,7 +80,7 @@ def test_tag_suffix_dataframe():
         "mapping_quality",
     ]
     df = parse_paf(PAF_IO, fields=cols + ["tags"], dataframe=True)
-    assert set(df.columns) == set(cols + ["cs", "tp_tag"]), "Tag field not set correctly"
+    assert set(df.columns) == set(cols + ["tp_tag"]), "Tag field not set correctly"
 
 
 def test_read_uncompressed():

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -82,6 +82,11 @@ def test_tag_suffix_dataframe():
     df = parse_paf(PAF_IO, fields=cols + ["tags"], dataframe=True)
     assert set(df.columns) == set(cols + ["tp_tag"]), "Tag field not set correctly"
 
+def test_cs_tag_parsing():
+    _rec = "a7208cb4-133c-4ab9-96fe-db8630f4d9bb\t373\t15\t368\t+\tEf_genome\t2845392\t586028\t586405\t103\t377\t60\ttp:A:P\tcs:Z::6-ata:10+gtc:4*at:3\n"
+    PAF_IO = StringIO(_rec)
+    for rec in parse_paf(PAF_IO):
+        assert rec.tags["cs"].value == ":6-ata:10+gtc:4*at:3", "cs tag didn't match"
 
 def test_read_uncompressed():
     c = 0


### PR DESCRIPTION
The CS tag from minimap2 contains `:`. However, current tag parsing splits on the `:`, leading to an error in pandas. This fixes that by setting the maximum number of splits on the tag.