### PR TITLE
GH-7 Parse empty PAF files

### DIFF
--- a/readpaf.py
+++ b/readpaf.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 __all__ = ["parse_paf"]
 
-__version__ = "0.0.10a1"
+__version__ = "0.0.10a2"
 
 try:
     import pandas as pd
@@ -186,7 +186,7 @@ def parse_paf(file_like, fields=None, na_values=None, na_rep=0, dataframe=False)
     if dataframe and pandas:
         df = pd.DataFrame(_paf_generator(file_like, fields, na_values, na_rep))
         if df.empty:
-            return df
+            return pd.DataFrame(columns=FIELDS)
         return _expand_dict_in_series(df, fields[-1])
     elif dataframe and not pandas:
         raise ImportError(e)

--- a/readpaf.py
+++ b/readpaf.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 __all__ = ["parse_paf"]
 
-__version__ = "0.0.9"
+__version__ = "0.0.10a1"
 
 try:
     import pandas as pd
@@ -184,10 +184,10 @@ def parse_paf(file_like, fields=None, na_values=None, na_rep=0, dataframe=False)
         raise ValueError("na_rep must be int or float")
 
     if dataframe and pandas:
-        return _expand_dict_in_series(
-            pd.DataFrame(_paf_generator(file_like, fields, na_values, na_rep)),
-            fields[-1],
-        )
+        df = pd.DataFrame(_paf_generator(file_like, fields, na_values, na_rep))
+        if df.empty:
+            return df
+        return _expand_dict_in_series(df, fields[-1])
     elif dataframe and not pandas:
         raise ImportError(e)
     else:

--- a/readpaf.py
+++ b/readpaf.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 __all__ = ["parse_paf"]
 
-__version__ = "0.0.10a2"
+__version__ = "0.0.10"
 
 try:
     import pandas as pd

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -19,6 +19,7 @@ STATIC_FILES = os.path.join(os.path.dirname(os.path.realpath(__file__)), "static
 PAF_FILE = os.path.join(STATIC_FILES, "test.paf")
 MISSING_LINE = os.path.join(STATIC_FILES, "test_blank_line.paf")
 UNMAPPED_REC = os.path.join(STATIC_FILES, "test_unmapped.paf")
+BLANK_PAF_FILE = os.path.join(STATIC_FILES, "test_blank.paf")
 
 DEFAULT_COLS = [
     "query_name",
@@ -140,6 +141,13 @@ def test_read_unmapped():
         for record in parse_paf(fh):
             c += 1
     assert c == 10, "Incorrect number of records"
+
+
+def test_empty_file():
+    with open(BLANK_PAF_FILE, "r") as fh:
+        df = parse_paf(fh, dataframe=True)
+    assert isinstance(df, pd.DataFrame), "Not a DataFrame"
+    assert df.shape == (0, 0), "Not the right shape {}".format(df.shape)
 
 
 def test_request_dataframe_without_pandas(monkeypatch):

--- a/tests/test_readpaf.py
+++ b/tests/test_readpaf.py
@@ -147,7 +147,7 @@ def test_empty_file():
     with open(BLANK_PAF_FILE, "r") as fh:
         df = parse_paf(fh, dataframe=True)
     assert isinstance(df, pd.DataFrame), "Not a DataFrame"
-    assert df.shape == (0, 0), "Not the right shape {}".format(df.shape)
+    assert df.shape == (0, 13), "Not the right shape {}".format(df.shape)
 
 
 def test_request_dataframe_without_pandas(monkeypatch):


### PR DESCRIPTION
Add a test case and skip parsing tags for empty pd.DataFrame.